### PR TITLE
fix: align `exports` field with readme instructions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
       }
     },
     "./runtime/*.js": "./esm/runtime/*.js",
-    "./react": {
-      "types": "./react.d.ts"
+    "./typings/*": {
+      "types": "./typings/*.d.ts"
     }
   },
   "main": "cjs/index.js",


### PR DESCRIPTION
Closes #30
